### PR TITLE
Enable class decoration 

### DIFF
--- a/AppSettings/AppSettings/AppSettingAttribute.cs
+++ b/AppSettings/AppSettings/AppSettingAttribute.cs
@@ -5,7 +5,10 @@ namespace AppSettings
     /// <summary>
     /// A code attribute for decorating a settings class' properties
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
+    /// <remarks>
+    /// As a convenience to avoid decorating each property, you may choose to attribte the class which will opt in all class public properties.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
     public sealed class AppSettingAttribute : Attribute
     {
         /// <summary>

--- a/AppSettings/AppSettings/AppSettingsLoader.cs
+++ b/AppSettings/AppSettings/AppSettingsLoader.cs
@@ -46,7 +46,8 @@ namespace AppSettings
                 string settingName = member.Name;
 
                 var attr = member.GetCustomAttribute<AppSettingAttribute>();
-                if (attr.Key != null)
+                if (attr != null &&
+                    attr.Key != null)
                 {
                     settingName = attr.Key;
                 }
@@ -90,6 +91,11 @@ namespace AppSettings
 
         private static bool HasAttribute(MemberInfo mi, object o)
         {
+            if (mi.DeclaringType.GetCustomAttribute<AppSettingAttribute>() != null)
+            {
+                return true;
+            }
+
             return mi.GetCustomAttribute<AppSettingAttribute>() != null;
         }
     }

--- a/AppSettings/AppSettingsTests/AppSettingsAttributeTests.cs
+++ b/AppSettings/AppSettingsTests/AppSettingsAttributeTests.cs
@@ -11,9 +11,9 @@ namespace AppSettingsTests
         public void AppSettingsAttribute_Specified()
         {
             string propertyName = "Override";
-            string attributeMemberName = "Name";
+            string attributeMemberName = "Key";
 
-            var nameArgument = GetName(propertyName, attributeMemberName);
+            var nameArgument = GetKey(propertyName, attributeMemberName);
 
             Assert.AreEqual("Overriden", nameArgument);
         }
@@ -24,19 +24,19 @@ namespace AppSettingsTests
             string propertyName = "Default";
             string attributeMemberName = "Name";
 
-            var nameArgument = GetName(propertyName, attributeMemberName);
+            var nameArgument = GetKey(propertyName, attributeMemberName);
 
             Assert.IsNull(nameArgument);
         }
 
-        private static string GetName(string propertyName, string attributeMemberName)
+        private static string GetKey(string propertyName, string attributeMemberName)
         {
             var test = new TestSettings();
             var defaultProperty = test.GetType().GetProperty(propertyName);
-            var fckAttribute = defaultProperty.CustomAttributes
+            var appSettingAttribute = defaultProperty.CustomAttributes
                 .Where(a => a.AttributeType == typeof(AppSettingAttribute))
                 .FirstOrDefault();
-            var nameArgument = fckAttribute.NamedArguments
+            var nameArgument = appSettingAttribute.NamedArguments
                 .Where(arg => arg.MemberName == attributeMemberName)
                 .FirstOrDefault();
 

--- a/AppSettings/AppSettingsTests/AppSettingsLoaderTests.cs
+++ b/AppSettings/AppSettingsTests/AppSettingsLoaderTests.cs
@@ -122,6 +122,30 @@ namespace AppSettingsTests
             Assert.IsTrue(exceptionCaught, "An exception was not thrown");
         }
 
+        [TestMethod]
+        public void AppSettingsLoader_Load_LoadsUndecoratedPropertyWhenClassIsDecorated()
+        {
+            var mockSettingsLoader = new SettingLoaderMock();
+            mockSettingsLoader.Settings.Add("Is42", "42");
+
+            var settings2 = new Settings2();
+
+            Assert.IsTrue(AppSettingsLoader.Load(mockSettingsLoader, ref settings2), "Load returned false");
+            Assert.AreEqual(42, settings2.Is42, "Int setting not set");
+        }
+
+        [TestMethod]
+        public void AppSettingsLoader_Load_UsesKeyOverride()
+        {
+            var mockSettingsLoader = new SettingLoaderMock();
+            mockSettingsLoader.Settings.Add("IsFooBar", "Foobar");
+
+            var settings2 = new Settings2();
+
+            Assert.IsTrue(AppSettingsLoader.Load(mockSettingsLoader, ref settings2), "Load returned false");
+            Assert.AreEqual("Foobar", settings2.IsFoo, "String setting not set");
+        }
+
         private class Settings
         {
             [AppSetting]
@@ -141,6 +165,15 @@ namespace AppSettingsTests
 
             [AppSetting]
             public Option IsOption2 { get; set; }
+        }
+
+        [AppSetting]
+        private class Settings2
+        {
+            public int Is42 { get; set; }
+
+            [AppSetting(Key = "IsFooBar")]
+            public string IsFoo { get; set; }
         }
 
         private enum Option

--- a/AppSettings/README.md
+++ b/AppSettings/README.md
@@ -1,11 +1,13 @@
 # Mash.AppSettings
 
-Tired of littering your code with ConfigurationManager.AppSettings["TheSetting"] and parsing the string the type you want? We'll make loading settings easy with very little code investment.
+Tired of littering your code with ConfigurationManager.AppSettings["TheSetting"] and parsing the string the type you want?
+Let's make loading settings easy with very little code investment.
 
 Just create a data class which holds properties representing the settings you wish to load, and then call Load().
 Mash.AppSettings use reflection on your data class to find public properties with our attribute and find a setting with that key in your app.config, and then set the value.
 
-Now your unit tests won't have problems if they call code which directly loaded from the app.config. Instead they can set your settings class with any values they want.
+Now your unit tests won't have problems if they call code which directly loaded from the app.config.
+Instead they can set your settings class with any values they want.
 This makes your code a lot more cohesive, and prevent unnecessary coupling to System.Configuration.
 
 Don't want to store settings in your app.config file? No problem!
@@ -19,7 +21,7 @@ AppSettingsLoader.Load(
     Factory.GetAppConfigSettingLoader(),
     ref settings);</code></pre>
 
-Your settings file will look like this:
+Your settings file will look something like this:
 <pre><code>class MySettings
 {
     [AppSetting]
@@ -28,6 +30,8 @@ Your settings file will look like this:
     [AppSetting(Key = "StringSettingOverride")]
     public string OverridenSetting { get; set; }
 }</code></pre>
+
+Or if you want to opt-in all public properties, you can just decorate the class with the AppSetting attribute.
 
 ## App.Config
 Included is support for loading settings from your app.config file.

--- a/AppSettings/SampleApp/PrintHelper.cs
+++ b/AppSettings/SampleApp/PrintHelper.cs
@@ -29,6 +29,11 @@ namespace SampleApp
 
         private static bool HasAttribute(MemberInfo mi, object o)
         {
+            if (mi.DeclaringType.GetCustomAttribute<AppSettingAttribute>() != null)
+            {
+                return true;
+            }
+
             return mi.GetCustomAttribute<AppSettingAttribute>() != null;
         }
     }

--- a/AppSettings/SampleApp/Settings.cs
+++ b/AppSettings/SampleApp/Settings.cs
@@ -6,36 +6,28 @@ namespace SampleApp
     /// <summary>
     /// Settings required for the running of this application
     /// </summary>
+    [AppSetting]
     internal class Settings
     {
-        [AppSetting]
         public string StringSetting { get; set; }
 
         [AppSetting(Key = "StringSettingOverride")]
         public string OverridenSetting { get; set; }
 
-        [AppSetting]
         public int IntSetting { get; set; }
 
-        [AppSetting]
         public uint UintSetting { get; set; }
 
-        [AppSetting]
         public DateTime DateTimeSetting { get; set; }
 
-        [AppSetting]
         public Guid GuidSetting { get; set; }
 
-        [AppSetting]
         public float FloatSetting { get; set; }
 
-        [AppSetting]
         public decimal DecimalSetting { get; set; }
 
-        [AppSetting]
         public EnumValues EnumSetting { get; set; }
 
-        [AppSetting]
         public EnumValues EnumSettingInt { get; set; }
     }
 

--- a/AppSettings/SampleWebApp/SettingsHelper.cs
+++ b/AppSettings/SampleWebApp/SettingsHelper.cs
@@ -34,6 +34,11 @@ namespace SampleWebApp
 
         private static bool HasAttribute(MemberInfo mi, object o)
         {
+            if (mi.DeclaringType.GetCustomAttribute<AppSettingAttribute>() != null)
+            {
+                return true;
+            }
+
             return mi.GetCustomAttribute<AppSettingAttribute>() != null;
         }
     }


### PR DESCRIPTION
Enable class decoration to encompass all properties, to reduce the number of attributes required when the entire class' public properties will be loaded